### PR TITLE
Add SignalR and Client Test Page

### DIFF
--- a/YoutubeDownloader.WebApi/Hubs/TestHub.cs
+++ b/YoutubeDownloader.WebApi/Hubs/TestHub.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.SignalR;
+
+public class TestHub : Hub
+{
+    public override async Task OnConnectedAsync()
+    {
+        await Clients.Caller.SendAsync("status", $"Connected: {Context.ConnectionId}");
+        await base.OnConnectedAsync();
+    }
+
+    public Task Ping() => Clients.All.SendAsync("status", "Pong");
+}

--- a/YoutubeDownloader.WebApi/Program.cs
+++ b/YoutubeDownloader.WebApi/Program.cs
@@ -1,0 +1,36 @@
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSignalR();
+
+builder.Services.AddCors(options => {
+    options.AddDefaultPolicy( policy => 
+        policy.WithOrigins("http://127.0.0.1:5500")
+           .AllowAnyMethod()
+           .AllowAnyHeader()
+           .AllowCredentials());
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors();
+app.MapGet("/", () => Results.Ok("Welcome to the Youtube Downloader Web API!"))
+.WithName("Quick health check")
+.WithOpenApi();
+
+app.MapHub<TestHub>("/hubs/test");
+
+
+app.Run();

--- a/YoutubeDownloader.WebApi/Properties/launchSettings.json
+++ b/YoutubeDownloader.WebApi/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:6228",
+      "sslPort": 44344
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5279",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7085;http://localhost:5279",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/YoutubeDownloader.WebApi/YoutubeDownloader.WebApi.csproj
+++ b/YoutubeDownloader.WebApi/YoutubeDownloader.WebApi.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/YoutubeDownloader.WebApi/YoutubeDownloader.WebApi.http
+++ b/YoutubeDownloader.WebApi/YoutubeDownloader.WebApi.http
@@ -1,0 +1,3 @@
+@YoutubeDownloader.WebApi_HostAddress = http://localhost:5279
+
+###

--- a/YoutubeDownloader.WebApi/appsettings.Development.json
+++ b/YoutubeDownloader.WebApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/YoutubeDownloader.WebApi/appsettings.json
+++ b/YoutubeDownloader.WebApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/YoutubeDownloader.sln
+++ b/YoutubeDownloader.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeDownloader.Core", "Y
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeDownloader.Infrastructure", "YoutubeDownloader.Infrastructure\YoutubeDownloader.Infrastructure.csproj", "{840B992B-8B58-4A0C-8541-4AE2718C9E07}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeDownloader.WebApi", "YoutubeDownloader.WebApi\YoutubeDownloader.WebApi.csproj", "{435F4583-FC74-43F4-9C43-75A43B9F3599}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{840B992B-8B58-4A0C-8541-4AE2718C9E07}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{840B992B-8B58-4A0C-8541-4AE2718C9E07}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{840B992B-8B58-4A0C-8541-4AE2718C9E07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{435F4583-FC74-43F4-9C43-75A43B9F3599}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{435F4583-FC74-43F4-9C43-75A43B9F3599}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{435F4583-FC74-43F4-9C43-75A43B9F3599}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{435F4583-FC74-43F4-9C43-75A43B9F3599}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>SignalR Test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      #log {
+        white-space: pre-wrap;
+        border: 1px solid #ccc;
+        padding: 8px;
+      }
+    </style>
+    <script src="https://unpkg.com/@microsoft/signalr@latest/dist/browser/signalr.min.js"></script>
+  </head>
+  <body>
+    <h1>SignalR Connection Test</h1>
+    <label
+      >Server URL:
+      <input
+        id="serverUrl"
+        size="40"
+        value="https://localhost:7085/hubs/test"
+      />
+    </label>
+    <button id="connectBtn">Connect</button>
+    <button id="pingBtn" disabled>Ping</button>
+    <div id="log" style="margin-top: 12px; height: 240px; overflow: auto"></div>
+
+    <script>
+      const log = (m) => {
+        const el = document.getElementById("log");
+        el.textContent += m + "\n";
+        el.scrollTop = el.scrollHeight;
+      };
+
+      let connection;
+
+      document.getElementById("connectBtn").onclick = async () => {
+        const url = document.getElementById("serverUrl").value.trim();
+        connection = new signalR.HubConnectionBuilder()
+          .withUrl(url)
+          .withAutomaticReconnect()
+          .build();
+
+        connection.on("status", (msg) => log(`[status] ${msg}`));
+
+        try {
+          await connection.start();
+          log("Connected to hub.");
+          document.getElementById("pingBtn").disabled = false;
+        } catch (err) {
+          log("Connection error: " + err);
+        }
+      };
+
+      document.getElementById("pingBtn").onclick = () => {
+        log(`[status] Sending Ping...`);
+        connection.invoke("Ping");
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Commits
- Add new web API project and install SignalR client
- Add test hub for ping/pong with client server communication 
- Configure Cors for client server handshake
- Add simple client-side page.

**Note**: Use live server vs-code extension to run html page in demo: https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer
### Screenshots
![screenshot-1](https://github.com/user-attachments/assets/cbece24a-34fe-4aca-8f76-64ee41e35f52)
