### PR TITLE
Implement download cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ An application for downloading and converting YouTube videos to audio files. Thi
 - Convert audio streams to MP3 format.
 - Embed cover images into MP3 files.
 - Real-time progress updates via SignalR.
-- Serve downloadable audio files via API endpoint.
+- Serve downloadable audio files.
 - Display songs in a scrollable list for play and download.
 - Modular architecture with extensible services.
 
 ## Demo
 
-![App Demo](https://private-user-images.githubusercontent.com/101366262/494123273-2f48a10c-5b03-4e07-b692-11529a9c18c3.gif?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTg4MzM4MjcsIm5iZiI6MTc1ODgzMzUyNywicGF0aCI6Ii8xMDEzNjYyNjIvNDk0MTIzMjczLTJmNDhhMTBjLTViMDMtNGUwNy1iNjkyLTExNTI5YTljMThjMy5naWY_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwOTI1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDkyNVQyMDUyMDdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT04OTcwOTBiNTU4MTJmZjExNDcwNjJhNjNkNzJmMTgwNGMxNTA0YmM0Y2E4NTBkYzNhMzg2MjAwZmQwNjYxMThkJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.xYwK4j3iS95zq5DDevmuJFX1j4m_wRyc3QT9lbqW1eY)
+![App Demo](https://private-user-images.githubusercontent.com/101366262/496762274-157df35a-6591-431c-ac4a-6d7d304772aa.gif?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTk0MjYzNTcsIm5iZiI6MTc1OTQyNjA1NywicGF0aCI6Ii8xMDEzNjYyNjIvNDk2NzYyMjc0LTE1N2RmMzVhLTY1OTEtNDMxYy1hYzRhLTZkN2QzMDQ3NzJhYS5naWY_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUxMDAyJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MTAwMlQxNzI3MzdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1lODFjZWRiZGVlNzMyNGIwNDc4NjFkODNlYjQ4Nzg4NGM0M2MyMmNiMDA1ODJlZjQ5ZDIzYzIzNWVkZGIzMTA1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.l9HkM9cd-xhCFCcGi2Jwl4tWpHgSbO86y6FKRgVSrSo)
 
 ## Getting Started
 
@@ -55,6 +55,7 @@ Open [http://localhost:4200](http://localhost:4200) in your browser.
 ## API Endpoints
 
 - `POST /api/download` — Start a new download request.
+- `POST /api/download/{taskId}/cancel` — Cancel download video request.
 - `GET /api/video` — Get video information such as title and duration.
 - `GET /api/song` — Get list of song has been download.
 - `POST /api/song` — Add a new song to the list.

--- a/YoutubeDownloader.ConsoleApp/Program.cs
+++ b/YoutubeDownloader.ConsoleApp/Program.cs
@@ -37,7 +37,7 @@ do
     {
         var audioDownloadService = services.GetRequiredService<AudioDownloadService>();
         var cancellationTokenSource = new CancellationTokenSource();
-        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(7));
+        cancellationTokenSource.CancelAfter(TimeSpan.FromHours(1));
         await audioDownloadService.ExecuteAsync(new DownloadRequest(videoUrl, saveFolder, startAt, endAt), cancellationTokenSource.Token);
     }
     catch (OperationCanceledException cancelException)

--- a/YoutubeDownloader.ConsoleApp/Program.cs
+++ b/YoutubeDownloader.ConsoleApp/Program.cs
@@ -33,8 +33,21 @@ do
         endAt = Console.ReadLine();
     }
 
-    var audioDownloadService = services.GetRequiredService<AudioDownloadService>();
-    await audioDownloadService.ExecuteAsync(new DownloadRequest(videoUrl, saveFolder, startAt, endAt));
+    try
+    {
+        var audioDownloadService = services.GetRequiredService<AudioDownloadService>();
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(7));
+        await audioDownloadService.ExecuteAsync(new DownloadRequest(videoUrl, saveFolder, startAt, endAt), cancellationTokenSource.Token);
+    }
+    catch (OperationCanceledException cancelException)
+    {
+        Console.WriteLine(cancelException.Message, cancelException.CancellationToken);
+    }
+    catch (ApplicationException appException)
+    {
+        Console.WriteLine(appException.Message, appException.Message);
+    }
 
     Console.Write("Done. Do you want to download more? (Enter/ESC): ");
 } while (Console.ReadKey().Key != ConsoleKey.Escape);

--- a/YoutubeDownloader.ConsoleApp/Services/YoutubeAudioDownloadService.cs
+++ b/YoutubeDownloader.ConsoleApp/Services/YoutubeAudioDownloadService.cs
@@ -8,28 +8,28 @@ public class YoutubeAudioDownloadService : AudioDownloadService
         : base(videoInfoProvider, audioConverter, audioCoverEmbedder, progress)
     { }
 
-    protected override Task<string> DownloadAudioStreamAsync(string videoUrl)
+    protected override Task<string> DownloadAudioStreamAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Downloading audio stream from Youtube...");
-        return base.DownloadAudioStreamAsync(videoUrl);
+        return base.DownloadAudioStreamAsync(videoUrl, cancellationToken);
     }
 
-    protected override Task<VideoModel> GetVideoInfoAsync(string videoUrl)
+    protected override Task<VideoModel> GetVideoInfoAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Fetching video info from Youtube...");
-        return base.GetVideoInfoAsync(videoUrl);
+        return base.GetVideoInfoAsync(videoUrl, cancellationToken);
     }
 
-    protected override Task<string> ConvertToMp3Async(AudioConversionRequest request)
+    protected override Task<string> ConvertToMp3Async(AudioConversionRequest request, CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Converting audio to MP3 format...");
-        return base.ConvertToMp3Async(request);
+        return base.ConvertToMp3Async(request, cancellationToken);
     }
 
-    protected override Task<string> GetCoverImageAsync(string videoUrl)
+    protected override Task<string> GetCoverImageAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
         Console.WriteLine("Downloading cover image...");
-        return base.GetCoverImageAsync(videoUrl);
+        return base.GetCoverImageAsync(videoUrl, cancellationToken);
     }
 
     protected override void EmbedCover(string audioOutputFilePath, string coverImagePath)

--- a/YoutubeDownloader.Core/Interfaces/IAudioConverter.cs
+++ b/YoutubeDownloader.Core/Interfaces/IAudioConverter.cs
@@ -1,4 +1,4 @@
 public interface IAudioConverter
 {
-    Task<string> ConvertToMp3Async(AudioConversionRequest request, IProgress<double>? progress = null);
+    Task<string> ConvertToMp3Async(AudioConversionRequest request, IProgress<double>? progress = null, CancellationToken cancellationToken = default);
 }

--- a/YoutubeDownloader.Core/Interfaces/IAudioCoverEmbedder.cs
+++ b/YoutubeDownloader.Core/Interfaces/IAudioCoverEmbedder.cs
@@ -1,5 +1,5 @@
 public interface IAudioCoverEmbedder
 {
-    Task<string> GetCoverImageAsync(string videoUrl, IProgress<double>? progress = null);
+    Task<string> GetCoverImageAsync(string videoUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default);
     void EmbedCover(string audioFilePath, string coverImagePath, IProgress<double>? progress = null);
 }

--- a/YoutubeDownloader.Core/Interfaces/IVideoInfoProvider.cs
+++ b/YoutubeDownloader.Core/Interfaces/IVideoInfoProvider.cs
@@ -1,5 +1,5 @@
 public interface IVideoInfoProvider
 {
-    Task<VideoModel> GetInfoAsync(string videoUrl, IProgress<double>? progress = null);
-    Task<string> DownloadAudioStreamAsync(string videoUrl, IProgress<double>? progress = null);
+    Task<VideoModel> GetInfoAsync(string videoUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default);
+    Task<string> DownloadAudioStreamAsync(string videoUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default);
 }

--- a/YoutubeDownloader.Core/Services/AudioDownloadService.cs
+++ b/YoutubeDownloader.Core/Services/AudioDownloadService.cs
@@ -20,6 +20,7 @@ public abstract class AudioDownloadService
     {
         string? audioStreamFilePath = null;
         string? coverImagePath = null;
+        string? audioOutputFilePath = null;
 
         try
         {
@@ -40,7 +41,7 @@ public abstract class AudioDownloadService
                 request.EndAt
             );
 
-            var audioOutputFilePath = await ConvertToMp3Async(conversionRequest, cancellationToken);
+            audioOutputFilePath = await ConvertToMp3Async(conversionRequest, cancellationToken);
 
             if (!string.IsNullOrEmpty(videoInfo.ThumbnailUrl))
             {
@@ -51,14 +52,18 @@ public abstract class AudioDownloadService
 
             OnCompleted(audioOutputFilePath);
         }
-        catch (OperationCanceledException cancelException)
+        catch (OperationCanceledException)
         {
-            Console.WriteLine(cancelException.Message, cancelException.CancellationToken);
+            if (!string.IsNullOrEmpty(audioOutputFilePath))
+            {
+                File.Delete(audioOutputFilePath);
+            }
+            throw;
         }
-        catch (Exception ex)
+        catch (Exception exception)
         {
             // Handle exceptions (e.g., log the error)
-            throw new ApplicationException("An error occurred during the audio download process.", ex);
+            throw new ApplicationException("An error occurred during the audio download process.", exception);
         }
         finally
         {

--- a/YoutubeDownloader.Infrastructure/Processors/AudioConverter.cs
+++ b/YoutubeDownloader.Infrastructure/Processors/AudioConverter.cs
@@ -39,9 +39,13 @@ public class AudioConverter : IAudioConverter
         {
             throw new OperationCanceledException($"Convert video to MP3 was cancelled.", cancelException.CancellationToken);
         }
+        catch (IOException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException($"Convert video to MP3 was cancelled.", cancellationToken);
+        }
         catch (Exception ex)
         {
             throw new InvalidOperationException("FFmpeg executables not found. Please ensure FFmpeg is installed and the path is set correctly.", ex);
-        }        
+        }
     }
 }

--- a/YoutubeDownloader.Infrastructure/Processors/AudioConverter.cs
+++ b/YoutubeDownloader.Infrastructure/Processors/AudioConverter.cs
@@ -1,7 +1,7 @@
 using Xabe.FFmpeg;
 public class AudioConverter : IAudioConverter
 {
-    public async Task<string> ConvertToMp3Async(AudioConversionRequest request, IProgress<double>? progress = null)
+    public async Task<string> ConvertToMp3Async(AudioConversionRequest request, IProgress<double>? progress = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -32,8 +32,12 @@ public class AudioConverter : IAudioConverter
                 var percent = Math.Round(args.Duration.TotalSeconds / args.TotalLength.TotalSeconds, 2);
                 progress?.Report(0.5 + percent * 0.3);
             };
-            await conversion.Start();
+            await conversion.Start(cancellationToken);
             return outputFilePath;
+        }
+        catch (OperationCanceledException cancelException)
+        {
+            throw new OperationCanceledException($"Convert video to MP3 was cancelled.", cancelException.CancellationToken);
         }
         catch (Exception ex)
         {

--- a/YoutubeDownloader.Infrastructure/Processors/AudioCoverEmbedder.cs
+++ b/YoutubeDownloader.Infrastructure/Processors/AudioCoverEmbedder.cs
@@ -1,15 +1,22 @@
 public class AudioCoverEmbedder : IAudioCoverEmbedder
 {
-    public async Task<string> GetCoverImageAsync(string videoUrl, IProgress<double>? progress = null)
+    public async Task<string> GetCoverImageAsync(string videoUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default)
     {
-        // Implementation for retrieving cover image from YouTube
-        progress?.Report(0.8);
-        using var http = new HttpClient();
-        byte[] coverBytes = await http.GetByteArrayAsync(videoUrl);
-        string tempCoverFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.jpg");
-        await File.WriteAllBytesAsync(tempCoverFile, coverBytes);
-        progress?.Report(0.9);
-        return tempCoverFile;
+        try
+        {
+            // Implementation for retrieving cover image from YouTube
+            progress?.Report(0.8);
+            using var http = new HttpClient();
+            byte[] coverBytes = await http.GetByteArrayAsync(videoUrl, cancellationToken);
+            string tempCoverFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.jpg");
+            await File.WriteAllBytesAsync(tempCoverFile, coverBytes, cancellationToken);
+            progress?.Report(0.9);
+            return tempCoverFile;
+        }
+        catch (OperationCanceledException cancelException)
+        {
+            throw new OperationCanceledException($"Get cover image for video url {videoUrl} was cancelled.", cancelException.CancellationToken);
+        }
     }
 
     public void EmbedCover(string audioFilePath, string coverImagePath, IProgress<double>? progress = null)

--- a/YoutubeDownloader.Infrastructure/Processors/VideoInfoProvider.cs
+++ b/YoutubeDownloader.Infrastructure/Processors/VideoInfoProvider.cs
@@ -4,13 +4,13 @@ using YoutubeExplode;
 public class VideoInfoProvider : IVideoInfoProvider
 {
     private readonly YoutubeClient _youtubeClient = new YoutubeClient();
-    public async Task<string> DownloadAudioStreamAsync(string videoUrl, IProgress<double>? progress = null)
+    public async Task<string> DownloadAudioStreamAsync(string videoUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default)
     {
         try
         {
             // Custom implementation for downloading audio stream from YouTube
             progress?.Report(0.1);
-            var streamManifest = await _youtubeClient.Videos.Streams.GetManifestAsync(videoUrl);
+            var streamManifest = await _youtubeClient.Videos.Streams.GetManifestAsync(videoUrl, cancellationToken);
             var audioStreams = streamManifest.GetAudioOnlyStreams();
             var bestAudio = audioStreams
                 .OrderByDescending(s => s.Bitrate)
@@ -23,9 +23,16 @@ public class VideoInfoProvider : IVideoInfoProvider
             var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.{ext}");
 
             // Download audio stream weight 40% of the progress
-            await _youtubeClient.Videos.Streams.DownloadAsync(bestAudio, tempFile, new Progress<double>(p => progress?.Report(0.1 + p * 0.4)));
+            await _youtubeClient.Videos.Streams.DownloadAsync(bestAudio,
+                tempFile,
+                new Progress<double>(p => progress?.Report(0.1 + p * 0.4)),
+                cancellationToken);
 
             return tempFile;
+        }
+        catch (OperationCanceledException cancelException)
+        {
+            throw new OperationCanceledException($"Download audio stream for video {videoUrl} was cancelled.", cancelException.CancellationToken);
         }
         catch (Exception ex)
         {
@@ -33,13 +40,13 @@ public class VideoInfoProvider : IVideoInfoProvider
         }
     }
 
-    public async Task<VideoModel> GetInfoAsync(string videoUrl, IProgress<double>? progress = null)
+    public async Task<VideoModel> GetInfoAsync(string videoUrl, IProgress<double>? progress = null, CancellationToken cancellationToken = default)
     {
         try
         {
             // Implementation for YouTube video info retrieval
             progress?.Report(0);
-            var video = await _youtubeClient.Videos.GetAsync(videoUrl);
+            var video = await _youtubeClient.Videos.GetAsync(videoUrl, cancellationToken);
             progress?.Report(0.1);
             return new VideoModel
             {
@@ -50,6 +57,10 @@ public class VideoInfoProvider : IVideoInfoProvider
                     .OrderBy(t => t.Resolution.Width * t.Resolution.Height)
                     .Last().Url
             };
+        }
+        catch (OperationCanceledException cancelException)
+        {
+            throw new OperationCanceledException($"Get video info from url {videoUrl} was cancelled.", cancelException.CancellationToken);
         }
         catch (Exception ex)
         {

--- a/YoutubeDownloader.Infrastructure/Processors/VideoInfoProvider.cs
+++ b/YoutubeDownloader.Infrastructure/Processors/VideoInfoProvider.cs
@@ -36,7 +36,7 @@ public class VideoInfoProvider : IVideoInfoProvider
         }
         catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.Forbidden)
         {
-            throw new HttpRequestException($"Downloading video is forbidden", httpRequestException);
+            throw new HttpRequestException($"Downloading this video is forbidden", httpRequestException);
         }
         catch (Exception ex)
         {            

--- a/YoutubeDownloader.Infrastructure/Processors/VideoInfoProvider.cs
+++ b/YoutubeDownloader.Infrastructure/Processors/VideoInfoProvider.cs
@@ -32,10 +32,14 @@ public class VideoInfoProvider : IVideoInfoProvider
         }
         catch (OperationCanceledException cancelException)
         {
-            throw new OperationCanceledException($"Download audio stream for video {videoUrl} was cancelled.", cancelException.CancellationToken);
+            throw new OperationCanceledException($"Downloading audio stream for video {videoUrl} was cancelled.", cancelException.CancellationToken);
+        }
+        catch (HttpRequestException httpRequestException) when (httpRequestException.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            throw new HttpRequestException($"Downloading video is forbidden", httpRequestException);
         }
         catch (Exception ex)
-        {
+        {            
             throw new InvalidOperationException("Failed to download audio stream from YouTube.", ex);
         }
     }

--- a/YoutubeDownloader.WebApi/Controller/DownloadController.cs
+++ b/YoutubeDownloader.WebApi/Controller/DownloadController.cs
@@ -5,15 +5,15 @@ using Microsoft.Extensions.Caching.Memory;
 [Route("api/[controller]")]
 public class DownloadController : ControllerBase
 {
-    private readonly AudioDownloadService _audioDownloadService;
+    private readonly IDownloadService _downloadService;
     private readonly IOutputStorage _outputStorage;
     private readonly IMemoryCache _memoryCache;
     public DownloadController(
-        AudioDownloadService audioDownloadService,
+        IDownloadService downloadService,
         IOutputStorage outputStorage,
         IMemoryCache memoryCache)
     {
-        _audioDownloadService = audioDownloadService;
+        _downloadService = downloadService;
         _outputStorage = outputStorage;
         _memoryCache = memoryCache;
     }
@@ -49,12 +49,25 @@ public class DownloadController : ControllerBase
                 }
             }
 
-            var _ = Task.Run(async () => await _audioDownloadService.ExecuteAsync(request));
-            return Ok(new { Message = "Request accepted. Processing download." });
+            var taskId = Guid.NewGuid().ToString();
+            _downloadService.ExecuteAsync(taskId, request);
+
+            return Ok(new
+            {
+                TaskId = taskId,
+                Message = $"Request task id {taskId} is accepted. Processing download."
+            });
         }
         catch (Exception ex)
         {
             return StatusCode(500, $"Internal server error: {ex.Message}");
         }
+    }
+
+    [HttpPost("{taskId}/cancel")]
+    public ActionResult CancelDownload(string taskId)
+    {
+        _downloadService.CancelTask(taskId);
+        return Ok($"Task Id: {taskId} was canceled");
     }
 }

--- a/YoutubeDownloader.WebApi/Controller/DownloadController.cs
+++ b/YoutubeDownloader.WebApi/Controller/DownloadController.cs
@@ -55,7 +55,7 @@ public class DownloadController : ControllerBase
             return Ok(new
             {
                 TaskId = taskId,
-                Message = $"Request task id {taskId} is accepted. Processing download."
+                Message = $"Request is accepted. Processing download."
             });
         }
         catch (Exception ex)
@@ -67,7 +67,18 @@ public class DownloadController : ControllerBase
     [HttpPost("{taskId}/cancel")]
     public ActionResult CancelDownload(string taskId)
     {
-        _downloadService.CancelTask(taskId);
-        return Ok($"Task Id: {taskId} was canceled");
+        try
+        {
+            _downloadService.CancelTask(taskId);
+            return Ok(new
+            {
+                TaskId = taskId,
+                Message = $"task was canceled"
+            });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, "Server cannot cancel {taskId}.");
+        }        
     }
 }

--- a/YoutubeDownloader.WebApi/Interfaces/IDownloadService.cs
+++ b/YoutubeDownloader.WebApi/Interfaces/IDownloadService.cs
@@ -1,0 +1,6 @@
+public interface IDownloadService
+{
+    DownloadTaskInfo ExecuteAsync(string taskId, DownloadRequest request);
+
+    void CancelTask(string taskId);
+}

--- a/YoutubeDownloader.WebApi/Model/DataStoreSettings.cs
+++ b/YoutubeDownloader.WebApi/Model/DataStoreSettings.cs
@@ -1,0 +1,6 @@
+public sealed class DataStoreSettings
+{
+    public string PublicBaseUrl { get; set; } = "https://localhost:7085";
+    public string SongDbDirectory { get; set; } = "json";
+    public string DbName { get; set; } = "song.json";
+}

--- a/YoutubeDownloader.WebApi/Model/DownloadTaskInfo.cs
+++ b/YoutubeDownloader.WebApi/Model/DownloadTaskInfo.cs
@@ -1,0 +1,6 @@
+public class DownloadTaskInfo
+{
+    public CancellationTokenSource Cancellation { get; set; } = default!;
+    public Task RunningTask { get; set; } = default!;
+    public DateTime StartAt { get; set; }
+}

--- a/YoutubeDownloader.WebApi/Model/ReportModel.cs
+++ b/YoutubeDownloader.WebApi/Model/ReportModel.cs
@@ -4,6 +4,7 @@ public enum ReportType
     Start = 0,
     Progress = 1,
     Completed = 2,
+    Cancel = 3,
 }
 public record ReportModel(
    ReportType Type,

--- a/YoutubeDownloader.WebApi/Model/SongModel.cs
+++ b/YoutubeDownloader.WebApi/Model/SongModel.cs
@@ -8,10 +8,3 @@ public record SongDto (
     string Title,
     string AudioUrl
 );
-
-public sealed class DataStoreSettings
-{
-    public string PublicBaseUrl { get; set; } = "https://localhost:7085";
-    public string SongDbDirectory { get; set; } = "json";
-    public string DbName { get; set; } = "song.json";
-}

--- a/YoutubeDownloader.WebApi/Program.cs
+++ b/YoutubeDownloader.WebApi/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddSingleton<IStageNotifier, StageNotifier>();
 builder.Services.AddSingleton<IProgress<double>, ProgressNotifier>();
 builder.Services.AddSingleton<IOutputStorage, LocalOutputStorage>();
 builder.Services.AddSingleton<ISongService, JsonSongService>();
+builder.Services.AddSingleton<IDownloadService, DownloadService>();
 
 builder.Services.AddSignalR().AddJsonProtocol(option =>
 {

--- a/YoutubeDownloader.WebApi/Service/DownloadService.cs
+++ b/YoutubeDownloader.WebApi/Service/DownloadService.cs
@@ -48,7 +48,7 @@ public class DownloadService : IDownloadService
 
             return newTask;
         }
-        catch (OperationCanceledException)
+        catch (Exception)
         {
             return new DownloadTaskInfo();
         }

--- a/YoutubeDownloader.WebApi/Service/DownloadService.cs
+++ b/YoutubeDownloader.WebApi/Service/DownloadService.cs
@@ -1,0 +1,56 @@
+
+using System.Collections.Concurrent;
+
+public class DownloadService : IDownloadService
+{
+    private readonly ConcurrentDictionary<string, DownloadTaskInfo> _tasksRegistry = new();
+
+    private readonly AudioDownloadService _audioDownloadService;
+
+    public DownloadService(AudioDownloadService audioDownloadService)
+    {
+        _audioDownloadService = audioDownloadService;
+    }
+
+    public void CancelTask(string taskId)
+    {
+        if (this._tasksRegistry.TryGetValue(taskId, out var taskInfo))
+        {
+            taskInfo.Cancellation.Cancel();
+            this._tasksRegistry.TryRemove(taskId, out var _);
+        }
+    }
+
+    public DownloadTaskInfo ExecuteAsync(string taskId, DownloadRequest request)
+    {
+        try
+        {
+            var cts = new CancellationTokenSource();
+            var token = cts.Token;
+            var startAt = DateTime.Now;
+
+            var task = Task.Run(async () =>
+            {
+                token.ThrowIfCancellationRequested();
+
+                await _audioDownloadService.ExecuteAsync(request, token);
+                
+            }, token);
+
+            var newTask = new DownloadTaskInfo
+            {
+                RunningTask = task,
+                Cancellation = cts,
+                StartAt = startAt
+            };
+
+            this._tasksRegistry.TryAdd(taskId, newTask);
+
+            return newTask;
+        }
+        catch (OperationCanceledException)
+        {
+            return new DownloadTaskInfo();
+        }
+    }
+}

--- a/YoutubeDownloader.WebApi/Service/YoutubeAudioDownloadService.cs
+++ b/YoutubeDownloader.WebApi/Service/YoutubeAudioDownloadService.cs
@@ -30,28 +30,48 @@ public class YoutubeAudioDownloadService : AudioDownloadService
     
     protected override async Task<VideoModel> GetVideoInfoAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
-        await _stageNotifier.ReportStageAsync(
-            new ReportModel(ReportType.Progress, "Fetching video information...", 1, 5));
-
-        _progressNotifier.Report(0.0);
-        if (_memoryCache.TryGetValue<VideoModel>(videoUrl, out var videoInfo))
+        try
         {
-            if (videoInfo is not null)
-            {
-                _progressNotifier.Report(0.1);
-                return videoInfo;
-            }
-        }
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Progress, "Fetching video information...", 1, 5));
 
-        videoInfo = await base.GetVideoInfoAsync(videoUrl, cancellationToken);
-        _progressNotifier.Report(0.1);
-        return videoInfo;
+            _progressNotifier.Report(0.0);
+            if (_memoryCache.TryGetValue<VideoModel>(videoUrl, out var videoInfo))
+            {
+                if (videoInfo is not null)
+                {
+                    _progressNotifier.Report(0.1);
+                    return videoInfo;
+                }
+            }
+
+            videoInfo = await base.GetVideoInfoAsync(videoUrl, cancellationToken);
+            _progressNotifier.Report(0.1);
+            return videoInfo;
+        }
+        catch (OperationCanceledException)
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Cancel, "Get video info was canceled.")
+            );
+            throw;
+        }
     }
     protected override async Task<string> DownloadAudioStreamAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
-        await _stageNotifier.ReportStageAsync(
-            new ReportModel(ReportType.Progress, "Starting audio download...", 2, 5));
-        return await base.DownloadAudioStreamAsync(videoUrl, cancellationToken);
+        try
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Progress, "Starting audio download...", 2, 5));
+            return await base.DownloadAudioStreamAsync(videoUrl, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Cancel, "Download audio stream was canceled.")
+            );
+            throw;
+        }
     }
     protected override async Task<string> ConvertToMp3Async(AudioConversionRequest request, CancellationToken cancellationToken = default)
     {
@@ -60,6 +80,13 @@ public class YoutubeAudioDownloadService : AudioDownloadService
             await _stageNotifier.ReportStageAsync(
                 new ReportModel(ReportType.Progress, "Converting audio to MP3...", 3, 5));
             return await base.ConvertToMp3Async(request, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Cancel, "Convert audio to MP3 was canceled.")
+            );
+            throw;
         }
         catch (Exception ex)
         {
@@ -70,9 +97,19 @@ public class YoutubeAudioDownloadService : AudioDownloadService
     }
     protected override async Task<string> GetCoverImageAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
-        await _stageNotifier.ReportStageAsync(
-            new ReportModel(ReportType.Progress, "Downloading cover image...", 4, 5));
-        return await base.GetCoverImageAsync(videoUrl, cancellationToken);
+        try
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Progress, "Downloading cover image...", 4, 5));
+            return await base.GetCoverImageAsync(videoUrl, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Cancel, "Download cover image was canceled.")
+            );
+            throw;
+        }
     }
     protected override async void EmbedCover(string audioOutputFilePath, string coverImagePath)
     {

--- a/YoutubeDownloader.WebApi/Service/YoutubeAudioDownloadService.cs
+++ b/YoutubeDownloader.WebApi/Service/YoutubeAudioDownloadService.cs
@@ -28,7 +28,7 @@ public class YoutubeAudioDownloadService : AudioDownloadService
             new ReportModel(ReportType.Start, "Download started...", 0, 5));
     }
     
-    protected override async Task<VideoModel> GetVideoInfoAsync(string videoUrl)
+    protected override async Task<VideoModel> GetVideoInfoAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
         await _stageNotifier.ReportStageAsync(
             new ReportModel(ReportType.Progress, "Fetching video information...", 1, 5));
@@ -43,23 +43,23 @@ public class YoutubeAudioDownloadService : AudioDownloadService
             }
         }
 
-        videoInfo = await base.GetVideoInfoAsync(videoUrl);
+        videoInfo = await base.GetVideoInfoAsync(videoUrl, cancellationToken);
         _progressNotifier.Report(0.1);
         return videoInfo;
     }
-    protected override async Task<string> DownloadAudioStreamAsync(string videoUrl)
+    protected override async Task<string> DownloadAudioStreamAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
         await _stageNotifier.ReportStageAsync(
             new ReportModel(ReportType.Progress, "Starting audio download...", 2, 5));
-        return await base.DownloadAudioStreamAsync(videoUrl);
+        return await base.DownloadAudioStreamAsync(videoUrl, cancellationToken);
     }
-    protected override async Task<string> ConvertToMp3Async(AudioConversionRequest request)
+    protected override async Task<string> ConvertToMp3Async(AudioConversionRequest request, CancellationToken cancellationToken = default)
     {
         try
         {
             await _stageNotifier.ReportStageAsync(
                 new ReportModel(ReportType.Progress, "Converting audio to MP3...", 3, 5));
-            return await base.ConvertToMp3Async(request);
+            return await base.ConvertToMp3Async(request, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -68,11 +68,11 @@ public class YoutubeAudioDownloadService : AudioDownloadService
             throw;
         }
     }
-    protected override async Task<string> GetCoverImageAsync(string videoUrl)
+    protected override async Task<string> GetCoverImageAsync(string videoUrl, CancellationToken cancellationToken = default)
     {
         await _stageNotifier.ReportStageAsync(
             new ReportModel(ReportType.Progress, "Downloading cover image...", 4, 5));
-        return await base.GetCoverImageAsync(videoUrl);
+        return await base.GetCoverImageAsync(videoUrl, cancellationToken);
     }
     protected override async void EmbedCover(string audioOutputFilePath, string coverImagePath)
     {

--- a/YoutubeDownloader.WebApi/Service/YoutubeAudioDownloadService.cs
+++ b/YoutubeDownloader.WebApi/Service/YoutubeAudioDownloadService.cs
@@ -72,6 +72,13 @@ public class YoutubeAudioDownloadService : AudioDownloadService
             );
             throw;
         }
+        catch (HttpRequestException httpRequestException)
+        {
+            await _stageNotifier.ReportStageAsync(
+                new ReportModel(ReportType.Error, httpRequestException.Message)
+            );
+            throw;
+        }
     }
     protected override async Task<string> ConvertToMp3Async(AudioConversionRequest request, CancellationToken cancellationToken = default)
     {

--- a/youtube-downloader-webui/src/app/model/report.model.ts
+++ b/youtube-downloader-webui/src/app/model/report.model.ts
@@ -1,5 +1,5 @@
 export interface IReport {
-  type: 'error' | 'start' | 'progress' | 'completed';
+  type: 'error' | 'start' | 'progress' | 'completed' | 'cancel';
   message: string;
   step?: number;
   totalSteps?: number;

--- a/youtube-downloader-webui/src/app/service/download-events.service.ts
+++ b/youtube-downloader-webui/src/app/service/download-events.service.ts
@@ -6,6 +6,7 @@ import { IProgressMessage, IReport } from '../model/report.model';
 export class DownloadEventsService {
   private readonly _error$: Subject<string> = new Subject<string>();
   private readonly _completed$: Subject<string> = new Subject<string>();
+  private readonly _cancel$: Subject<string> = new Subject<string>();
   private readonly _progress$: Subject<IProgressMessage> =
     new Subject<IProgressMessage>();
   private readonly _start$: Subject<void> = new Subject<void>();
@@ -20,14 +21,7 @@ export class DownloadEventsService {
   public completed$ = this._completed$.asObservable();
   public progress$ = this._progress$.asObservable();
   public start$ = this._start$.asObservable();
-
-  updateCompletedMessage(arg: string) {
-    this._completed$.next(arg);
-  }
-
-  updateErrorMessage(arg: string) {
-    this._error$.next(arg);
-  }
+  public cancel$ = this._cancel$.asObservable();
 
   public dispatchEvent(report: IReport) {
     switch (report.type) {
@@ -39,6 +33,9 @@ export class DownloadEventsService {
         break;
       case 'completed':
         this._completed$.next(report.message);
+        break;
+      case 'cancel':
+        this._cancel$.next(report.message);
         break;
       default:
         this._error$.next(report.message);

--- a/youtube-downloader-webui/src/app/service/download-events.service.ts
+++ b/youtube-downloader-webui/src/app/service/download-events.service.ts
@@ -67,7 +67,6 @@ export class DownloadEventsService {
   private init() {
     this._currentStep = 0;
     this._progressMessage.clear();
-    this._error$.next('');
     this._start$.next();
   }
 }

--- a/youtube-downloader-webui/src/app/store/state/video.model.ts
+++ b/youtube-downloader-webui/src/app/store/state/video.model.ts
@@ -10,3 +10,8 @@ export interface DownloadVideo {
   startAt: string;
   endAt: string;
 }
+
+export interface RunningTask {
+  taskId: string;
+  message: string;
+}

--- a/youtube-downloader-webui/src/app/store/state/video.state.ts
+++ b/youtube-downloader-webui/src/app/store/state/video.state.ts
@@ -1,7 +1,7 @@
-import { Video } from './video.model';
+import { RunningTask, Video } from './video.model';
 
 export interface VideoState {
-  item: Video;
+  item: Video & RunningTask;
   error: any;
 }
 
@@ -10,6 +10,8 @@ export const initialVideoState: VideoState = {
     videoUrl: '',
     title: '',
     duration: '',
+    taskId: '',
+    message: '',
   },
   error: '',
 };

--- a/youtube-downloader-webui/src/app/store/video/video.actions.ts
+++ b/youtube-downloader-webui/src/app/store/video/video.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from '@ngrx/store';
-import { DownloadVideo, Video } from '../state/video.model';
+import { DownloadVideo, RunningTask, Video } from '../state/video.model';
 
 export enum VideoActionTypes {
   getVideoInfo = '[Video API] Get Youtube Video by URL',
@@ -8,6 +8,9 @@ export enum VideoActionTypes {
   downloadVideo = '[Video API] Download Video and Convert to a Audio',
   downloadVideoSuccess = '[Video API] Download Video Success',
   downloadVideoFail = '[Video API] Download Video Error',
+  cancelDownload = '[Video API] Cancel Video Download',
+  cancelDownloadSuccess = '[Video API] Cancel Video Download Success',
+  cancelDownloadFail = '[Video API] Cancel Video Download Error',
 }
 
 export const getVideoInfo = createAction(
@@ -37,5 +40,20 @@ export const downloadVideoSuccess = createAction(
 
 export const downloadVideoFail = createAction(
   VideoActionTypes.downloadVideoFail,
+  props<{ error: string }>()
+);
+
+export const cancelDownload = createAction(
+  VideoActionTypes.cancelDownload,
+  props<{ taskId: string }>()
+);
+
+export const cancelDownloadSuccess = createAction(
+  VideoActionTypes.cancelDownloadSuccess,
+  props<{ payload: RunningTask }>()
+);
+
+export const cancelDownloadFail = createAction(
+  VideoActionTypes.cancelDownloadFail,
   props<{ error: string }>()
 );

--- a/youtube-downloader-webui/src/app/store/video/video.reducer.ts
+++ b/youtube-downloader-webui/src/app/store/video/video.reducer.ts
@@ -1,6 +1,10 @@
 import { createReducer, on } from '@ngrx/store';
 import { initialVideoState } from '../state/video.state';
 import {
+  cancelDownload,
+  cancelDownloadFail,
+  cancelDownloadSuccess,
+  downloadVideo,
   downloadVideoFail,
   downloadVideoSuccess,
   getVideoInfo,
@@ -13,7 +17,7 @@ export const videoReducer = createReducer(
   on(getVideoInfo, (state) => ({ ...state })),
   on(getVideoInfoSuccess, (state, { payload }) => ({
     ...state,
-    item: payload,
+    item: { ...state.item, ...payload },
   })),
   on(getVideoInfoFail, (state, { videoUrl, error }) => ({
     ...state,
@@ -23,11 +27,34 @@ export const videoReducer = createReducer(
     },
     error: error,
   })),
+  on(downloadVideo, (state) => ({
+    ...state,
+    item: {
+      ...state.item,
+      taskId: '',
+      message: '',
+    },
+  })),
   on(downloadVideoSuccess, (state, { payload }) => ({
     ...state,
-    item: { ...state.item, title: payload.title, videoUrl: payload.videoUrl },
+    item: {
+      ...state.item,
+      ...payload,
+    },
   })),
   on(downloadVideoFail, (state, { error }) => ({
+    ...state,
+    error: error,
+  })),
+  on(cancelDownload, (state) => ({ ...state })),
+  on(cancelDownloadSuccess, (state, { payload }) => ({
+    ...state,
+    item: {
+      ...state.item,
+      ...payload,
+    },
+  })),
+  on(cancelDownloadFail, (state, { error }) => ({
     ...state,
     error: error,
   }))

--- a/youtube-downloader-webui/src/app/store/video/video.selector.ts
+++ b/youtube-downloader-webui/src/app/store/video/video.selector.ts
@@ -8,3 +8,8 @@ export const videoInfoSelector = createSelector(
   videoSelector,
   (state: VideoState) => state.item
 );
+
+export const taskIdSelector = createSelector(
+  videoSelector,
+  (state: VideoState) => state.item.taskId
+);

--- a/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.html
+++ b/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.html
@@ -20,5 +20,16 @@
   </ng-container>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close>Close</button>
+  <ng-container *ngIf="canCancel$ | async">
+    <button
+      *ngIf="taskId$ | async as taskId"
+      mat-button
+      (click)="handleCancel(taskId)"
+    >
+      Cancel
+    </button>
+  </ng-container>
+  <button *ngIf="!(canCancel$ | async)" mat-button mat-dialog-close>
+    Close
+  </button>
 </mat-dialog-actions>

--- a/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.html
+++ b/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.html
@@ -29,7 +29,5 @@
       Cancel
     </button>
   </ng-container>
-  <button *ngIf="!(canCancel$ | async)" mat-button mat-dialog-close>
-    Close
-  </button>
+  <button *ngIf="canClose$ | async" mat-button mat-dialog-close>Close</button>
 </mat-dialog-actions>

--- a/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.ts
+++ b/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.ts
@@ -32,13 +32,18 @@ export class VideoDialogComponent {
   readonly cancelMessage$ = this._downloadEventsService.cancel$;
   readonly taskId$ = this._store.select(taskIdSelector);
 
-  readonly canCancel$ = merge(this.cancelMessage$, this.completedMessage$).pipe(
-    map(() => false),
-    startWith(true)
-  );
+  private readonly _cancelledOrCompleted$ = merge(
+    this._downloadEventsService.cancel$,
+    this._downloadEventsService.completed$
+  ).pipe(map(() => true));
+
+  readonly canCancel$ = merge(
+    this._cancelledOrCompleted$.pipe(map((value) => !value)),
+    this.errorMessage$.pipe(map(() => false))
+  ).pipe(startWith(true));
 
   readonly canClose$ = merge(
-    this.canCancel$.pipe(map((value) => !value)),
+    this._cancelledOrCompleted$,
     this.errorMessage$.pipe(map(() => true))
   );
 

--- a/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.ts
+++ b/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.ts
@@ -4,6 +4,11 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatButtonModule } from '@angular/material/button';
 import { DownloadEventsService } from '../../service/download-events.service';
+import { Store } from '@ngrx/store';
+import { AppState } from '../../store/state';
+import { taskIdSelector } from '../../store/video/video.selector';
+import { VideoActionTypes } from '../../store/video/video.actions';
+import { map, merge, startWith } from 'rxjs';
 
 @Component({
   templateUrl: './video-dialog.component.html',
@@ -19,8 +24,20 @@ import { DownloadEventsService } from '../../service/download-events.service';
 })
 export class VideoDialogComponent {
   private readonly _downloadEventsService = inject(DownloadEventsService);
+  private readonly _store = inject(Store<AppState>);
 
   readonly progressMessage$ = this._downloadEventsService.progress$;
   readonly errorMessage$ = this._downloadEventsService.error$;
   readonly completedMessage$ = this._downloadEventsService.completed$;
+  readonly cancelMessage$ = this._downloadEventsService.cancel$;
+  readonly taskId$ = this._store.select(taskIdSelector);
+
+  readonly canCancel$ = merge(this.cancelMessage$, this.completedMessage$).pipe(
+    map(() => false),
+    startWith(true)
+  );
+
+  handleCancel(taskId: string) {
+    this._store.dispatch({ type: VideoActionTypes.cancelDownload, taskId });
+  }
 }

--- a/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.ts
+++ b/youtube-downloader-webui/src/app/video/dialog/video-dialog.component.ts
@@ -37,6 +37,11 @@ export class VideoDialogComponent {
     startWith(true)
   );
 
+  readonly canClose$ = merge(
+    this.canCancel$.pipe(map((value) => !value)),
+    this.errorMessage$.pipe(map(() => true))
+  );
+
   handleCancel(taskId: string) {
     this._store.dispatch({ type: VideoActionTypes.cancelDownload, taskId });
   }

--- a/youtube-downloader-webui/src/app/video/form/video-form.component.ts
+++ b/youtube-downloader-webui/src/app/video/form/video-form.component.ts
@@ -103,7 +103,7 @@ export class VideoFormComponent implements OnInit, OnDestroy {
       },
     });
 
-    this._dialog.open(VideoDialogComponent);
+    this._dialog.open(VideoDialogComponent, { disableClose: true });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
### Commits

- Enable cancellation on service `AudioDownloadService`
- Wrap `YoutubeAudioDownloadService` inside `DownloadService` for managing running task in thread pool. 
- Add new `POST` endpoint for cancellation `api/download/{taskId}/cancel`
- Add new `Cancel` button
- Extended video state with running task
- Handle error 403 downloading forbidden video.

### Screenshot
- Download
![output_3](https://github.com/user-attachments/assets/157df35a-6591-431c-ac4a-6d7d304772aa)

- Cancel download
![output_2](https://github.com/user-attachments/assets/d321c6fb-5f0a-4ccd-b6c5-5565b5c9cf6a)
